### PR TITLE
Make compiler respect default nvcc flags

### DIFF
--- a/quantumsim/dm10.py
+++ b/quantumsim/dm10.py
@@ -12,7 +12,7 @@ from . import ptm
 import pycuda.autoinit
 
 # load the kernels
-from pycuda.compiler import SourceModule
+from pycuda.compiler import SourceModule, DEFAULT_NVCC_FLAGS
 
 import sys
 import os
@@ -30,7 +30,7 @@ for kernel_file in [
     try:
         with open(kernel_file, "r") as kernel_source_file:
             mod = SourceModule(
-                kernel_source_file.read(), options=[
+                kernel_source_file.read(), options=DEFAULT_NVCC_FLAGS+[
                     "--default-stream", "per-thread", "-lineinfo"])
             break
     except FileNotFoundError:
@@ -144,7 +144,7 @@ class Density:
 
         tr0 = self.diag_work[0].get()
 
-        return tr0 
+        return tr0
 
     def renormalize(self):
         """Renormalize to trace one."""


### PR DESCRIPTION
Plugging yur own options overwrites PYCUDA_DEFAULT_NVCC_FLAGS action, so there is no possibility left to plug custom options (for example, CUDA include directory).